### PR TITLE
Add json import

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ python -m pip install kutana
 > and plugins are loaded from folder "plugins/"
 
 ```py
+import json
+
 from kutana import *
 
 # Load configuration

--- a/README.ru.md
+++ b/README.ru.md
@@ -42,6 +42,8 @@ python -m pip install kutana
 > а плагины будут загружены из папки "plugins/"
 
 ```py
+import json
+
 from kutana import *
 
 # Загрузка настроек


### PR DESCRIPTION
Just a small pr to fix a problem with the README's example.

## Description
There is no `import json` in the README example, even though it's present in `examples/run.py`.

https://github.com/ekonda/kutana/blob/828a03d5632f178d6afc670632b7af470dd7c472/example/run.py#L1

## Motivation and Context
Just a small issue I had with the README

## How Has This Been Tested?
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
