### PR TITLE
Fix import module when load plugins from file to allow some pickle cases

### DIFF
--- a/kutana/loaders.py
+++ b/kutana/loaders.py
@@ -1,6 +1,7 @@
 import importlib.util
 import os
 import re
+import sys
 
 from .i18n import load_translations
 from .logger import logger
@@ -18,6 +19,7 @@ def import_module(name, path):
 
     spec = importlib.util.spec_from_file_location(name, os.path.abspath(path))
     module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
     spec.loader.exec_module(module)
 
     return module

--- a/kutana/loaders.py
+++ b/kutana/loaders.py
@@ -33,7 +33,8 @@ def load_plugins_from_file(path, verbose=False):
     :returns: loaded module or None if no plugin found
     """
 
-    mod = import_module(path, path)
+    name = path.split(".py")[0].replace("/", ".")
+    mod = import_module(name, path)
 
     plugins = []
 

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -1,4 +1,7 @@
+import pickle
 from os.path import dirname
+from unittest.mock import patch
+
 from kutana.loaders import load_plugins
 
 
@@ -7,3 +10,13 @@ def test_load_plugins():
 
     assert len(plugins) == 3
     assert {"echo", "hello 1", "hello 2"} == set(p.name for p in plugins)
+
+
+@patch("kutana.plugin.Plugin.on_match")  # on_match is incompatible with pickle
+def test_pickle_dumps(_):
+    plugins = load_plugins("tests/assets", verbose=True)
+
+    assert len(plugins) == 3
+    assert {"echo", "hello 1", "hello 2"} == set(p.name for p in plugins)
+
+    pickle.dumps(plugins)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

1. Fix the `name` of the module to be imported in `load_plugins_from_file`.
2. Fix the missing step in `import_module` that inserts the module into `sys.modules` as shown in the recipe https://docs.python.org/3/library/importlib.html#importing-a-source-file-directly.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Pickling a plugin that has a reference to a function or class defined within the plugin module fails.  
See [https://stackoverflow.com/questions/74841508/cant-pickle-class-import-of-module-failed](https://stackoverflow.com/a/74873028/8601760).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added `test_pickle_dumps` in test_loaders.py, which fails before this fix and passes after this fix.  

Limitations:
- Pickling only works for the reference if `load_plugins` from relative path.
- `on_match` is incompatible with `pickle`, but works with `cloudpickle`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] ~~New feature (non-breaking change which adds functionality)~~
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] ~~My change requires a change to the documentation.~~
- [ ] ~~I have updated the documentation accordingly.~~
- [x] I have added tests to cover my changes.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
